### PR TITLE
Update API key variable name in test workflow

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -49,4 +49,4 @@ jobs:
     - name: Run Infection
       run: ./infection.phar --min-msi=100 --threads=4
       env:
-        INFECTION_DASHBOARD_API_KEY: ${{ secrets.INFECTION_DASHBOARD_API_KEY }}
+        STRYKER_DASHBOARD_API_KEY: ${{ secrets.INFECTION_DASHBOARD_API_KEY }}


### PR DESCRIPTION
In the GitHub Actions Workflow for running PHP Infection tests, the name of the environment variable storing the dashboard API key has been changed. It was originally INFECTION_DASHBOARD_API_KEY, but it has been renamed to STRYKER_DASHBOARD_API_KEY to match the service used for reporting test results.