### PR TITLE
Update API key variable name in PHP workflow

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -47,6 +47,8 @@ jobs:
         chmod +x infection.phar
 
     - name: Run Infection
-      run: ./infection.phar --min-msi=100 --threads=4
+      run: |
+        ./infection.phar --min-msi=100 --threads=4
+        echo ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
       env:
         STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -47,8 +47,6 @@ jobs:
         chmod +x infection.phar
 
     - name: Run Infection
-      run: |
-        ./infection.phar --min-msi=100 --threads=4
-        echo ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
+      run: ./infection.phar --min-msi=100 --threads=4
       env:
         STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -49,4 +49,4 @@ jobs:
     - name: Run Infection
       run: ./infection.phar --min-msi=100 --threads=4
       env:
-        STRYKER_DASHBOARD_API_KEY: ${{ secrets.INFECTION_DASHBOARD_API_KEY }}
+        STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}


### PR DESCRIPTION
The environment variable for the API key in the GitHub Actions workflow was updated. It changed from INFECTION_DASHBOARD_API_KEY to STRYKER_DASHBOARD_API_KEY, reflecting the service used for reporting test results.