### PR TITLE
Add Codecov action to Github workflow

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: PestPHP
         run: ./vendor/bin/pest --coverage-clover=coverage.xml
+        env:
+          XDEBUG_MODE: coverage
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -33,7 +33,7 @@ jobs:
         run: composer install --prefer-dist --no-progress
 
       - name: PestPHP
-        run: ./vendor/bin/pest --coverage-clover=/coverage.xml
+        run: ./vendor/bin/pest --coverage-clover /coverage.xml
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -33,12 +33,12 @@ jobs:
         run: composer install --prefer-dist --no-progress
 
       - name: PestPHP
-        run: ./vendor/bin/pest --coverage-clover=./coverage.xml
+        run: ./vendor/bin/pest --coverage-clover=/coverage.xml
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:
-          files: ./coverage.xml
+          files: /coverage.xml
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -33,12 +33,12 @@ jobs:
         run: composer install --prefer-dist --no-progress
 
       - name: PestPHP
-        run: ./vendor/bin/pest --coverage-clover ./coverage.xml
+        run: ./vendor/bin/pest --coverage-clover=coverage.xml
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:
-          files: ./coverage.xml
+          files: ${{ github.workspace }}/coverage.xml
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -37,6 +37,8 @@ jobs:
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
+        with:
+          files: ./coverage.xml
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -33,12 +33,12 @@ jobs:
         run: composer install --prefer-dist --no-progress
 
       - name: PestPHP
-        run: ./vendor/bin/pest --coverage-clover /coverage.xml
+        run: ./vendor/bin/pest --coverage-clover ./coverage.xml
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:
-          files: /coverage.xml
+          files: ./coverage.xml
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -33,7 +33,7 @@ jobs:
         run: composer install --prefer-dist --no-progress
 
       - name: PestPHP
-        run: ./vendor/bin/pest --parallel --coverage-clover
+        run: ./vendor/bin/pest --parallel --coverage-clover=coverage.xml
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -33,7 +33,12 @@ jobs:
         run: composer install --prefer-dist --no-progress
 
       - name: PestPHP
-        run: ./vendor/bin/pest --parallel
+        run: ./vendor/bin/pest --parallel --coverage-clover
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Download Infection
         run: |
@@ -48,8 +53,3 @@ jobs:
 
       - name: Run Infection
         run: ./infection.phar --min-msi=100 --threads=4
-
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -15,36 +15,41 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Validate composer.json and composer.lock
-      run: composer validate --strict
+      - name: Validate composer.json and composer.lock
+        run: composer validate --strict
 
-    - name: Cache Composer packages
-      id: composer-cache
-      uses: actions/cache@v3
-      with:
-        path: vendor
-        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-php-
+      - name: Cache Composer packages
+        id: composer-cache
+        uses: actions/cache@v3
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-
 
-    - name: Install dependencies
-      run: composer install --prefer-dist --no-progress
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
 
-    - name: PestPHP 
-      run: ./vendor/bin/pest --parallel
+      - name: PestPHP
+        run: ./vendor/bin/pest --parallel
 
-    - name: Download Infection
-      run: |
-        wget https://github.com/infection/infection/releases/download/0.27.0/infection.phar
-        wget https://github.com/infection/infection/releases/download/0.27.0/infection.phar.asc
+      - name: Download Infection
+        run: |
+          wget https://github.com/infection/infection/releases/download/0.27.0/infection.phar
+          wget https://github.com/infection/infection/releases/download/0.27.0/infection.phar.asc
 
-    - name: Verify Infection
-      run: |
-        gpg --recv-keys C6D76C329EBADE2FB9C458CFC5095986493B4AA0
-        gpg --with-fingerprint --verify infection.phar.asc infection.phar
-        chmod +x infection.phar
+      - name: Verify Infection
+        run: |
+          gpg --recv-keys C6D76C329EBADE2FB9C458CFC5095986493B4AA0
+          gpg --with-fingerprint --verify infection.phar.asc infection.phar
+          chmod +x infection.phar
 
-    - name: Run Infection
-      run: ./infection.phar --min-msi=100 --threads=4
+      - name: Run Infection
+        run: ./infection.phar --min-msi=100 --threads=4
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -39,8 +39,6 @@ jobs:
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
-        with:
-          files: ${{ github.workspace }}/coverage.xml
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -33,7 +33,7 @@ jobs:
         run: composer install --prefer-dist --no-progress
 
       - name: PestPHP
-        run: ./vendor/bin/pest --parallel --coverage-clover=coverage.xml
+        run: ./vendor/bin/pest --coverage-clover=./coverage.xml
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
This change adds a new step to the Github CI workflow to upload coverage reports to Codecov. It's essential for visualizing and tracking our testing coverage over time and ensures that we can easily check the test coverage of each pull request.