### PR TITLE
Switch Docker setup to custom build with Xdebug

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,8 @@ version: '3'
 
 services:
   app:
-    image: php:8.1-fpm
+    build:
+      context: ./docker/app
     working_dir: /app
     volumes:
       - .:/app

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -1,0 +1,8 @@
+# Dockerfile
+FROM php:8.1-fpm
+
+# Install Xdebug
+RUN pecl install xdebug && docker-php-ext-enable xdebug
+
+# Copy xdebug configuration
+COPY ./xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini

--- a/docker/app/xdebug.ini
+++ b/docker/app/xdebug.ini
@@ -1,0 +1,4 @@
+; xdebug.ini
+zend_extension = xdebug.so
+xdebug.mode = coverage
+xdebug.start_with_request = yes


### PR DESCRIPTION
Switched from using the php:8.1-fpm image directly, to building a custom Docker image that includes Xdebug. This allows for more flexibility if other customizations are needed later and enables code coverage features in the development environment.