### PR TITLE
Exclude 'CastMethod' and 'Cast' classes from code coverage

### DIFF
--- a/src/Attributes/Cast.php
+++ b/src/Attributes/Cast.php
@@ -1,5 +1,5 @@
 <?php
-
+// @codeCoverageIgnoreStart
 namespace Zerotoprod\ServiceModel\Attributes;
 
 use Attribute;
@@ -11,3 +11,4 @@ class Cast
     {
     }
 }
+// @codeCoverageIgnoreEnd

--- a/src/Attributes/CastMethod.php
+++ b/src/Attributes/CastMethod.php
@@ -1,5 +1,5 @@
 <?php
-
+// @codeCoverageIgnoreStart
 namespace Zerotoprod\ServiceModel\Attributes;
 
 use Attribute;
@@ -11,3 +11,4 @@ class CastMethod
     {
     }
 }
+// @codeCoverageIgnoreEnd


### PR DESCRIPTION
Code coverage tags have been added to 'CastMethod.php' and 'Cast.php' to exclude these files from the code coverage report. This is to ensure that these files, which are utility classes without much logic, do not affect the overall testing coverage statistics.