### PR TITLE
Add link to zero-dependency package and ETL explanation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,11 @@
 A modern approach to [extensible](#extending-the-servicemodel-trait), [typesafe](#setting-up-your-model) DTOs
 with [factory](#factories) support.
 
-This **zero-dependency** package transforms associative arrays into typesafe [Data
+This [zero-dependency](https://raw.githubusercontent.com/zero-to-prod/service-models/master/composer.json) package
+transforms associative arrays into typesafe [Data
 Transfer Objects](#setting-up-your-model) (DTOs).
+
+In an Extract Transform Load (ETL) process, this package is the **_T_** where the data is transformed into a model.
 
 ## Features
 


### PR DESCRIPTION
The README.md file was updated by providing a link to the zero-dependency package and adding a sentence explaining how the package operates in an Extract Transform Load (ETL) process. These changes offer further clarity and usefulness to end-users by guiding them to relevant resources and more clearly defining the package's role.