### PR TITLE
Remove Narrowing for ServiceModels

### DIFF
--- a/src/ServiceModel.php
+++ b/src/ServiceModel.php
@@ -86,11 +86,8 @@ trait ServiceModel
 
                 // ServiceModels
                 if (method_exists($model_classname, 'make')) {
-                    $trait_names = (new ReflectionClass($model_classname))->getTraitNames();
-                    if (in_array(ServiceModel::class, $trait_names, true)) {
-                        $self->{$key} = $model_classname::make($value);
-                        continue;
-                    }
+                    $self->{$key} = $model_classname::make($value);
+                    continue;
                 }
 
                 // Enums


### PR DESCRIPTION
This change simplifies the process of creating models in the ServiceModel by removing the trait check. The model is now directly instantiated using the 'make' method, which improves code readability and execution efficiency.