### PR TITLE
Add test classes and unit test for ServiceModel extension

### DIFF
--- a/tests/Models/ExtensionChildClass.php
+++ b/tests/Models/ExtensionChildClass.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Zerotoprod\AppServiceModel\Tests\Models;
+
+use Zerotoprod\AppServiceModel\Tests\Traits\TestServiceModel;
+
+class ExtensionChildClass
+{
+    use TestServiceModel;
+
+    public const name = 'name';
+    public const id = 'id';
+    public readonly string $name;
+    public int $id;
+}

--- a/tests/Models/ExtensionClass.php
+++ b/tests/Models/ExtensionClass.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Zerotoprod\AppServiceModel\Tests\Models;
+
+use Zerotoprod\AppServiceModel\Tests\Traits\TestServiceModel;
+
+class ExtensionClass
+{
+    use TestServiceModel;
+
+    public const child = 'child';
+    public ExtensionChildClass $child;
+}

--- a/tests/Traits/TestServiceModel.php
+++ b/tests/Traits/TestServiceModel.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Zerotoprod\AppServiceModel\Tests\Traits;
+
+use Zerotoprod\ServiceModel\ServiceModel;
+
+trait TestServiceModel
+{
+    use ServiceModel;
+}

--- a/tests/Unit/ExtensionTest.php
+++ b/tests/Unit/ExtensionTest.php
@@ -1,0 +1,14 @@
+<?php
+
+use Zerotoprod\AppServiceModel\Tests\Models\Child;
+use Zerotoprod\AppServiceModel\Tests\Models\ExtensionClass;
+
+test('extension', function () {
+    $ExtensionClass = ExtensionClass::make([
+        ExtensionClass::child => [
+            Child::name => 'value',
+        ]
+    ]);
+
+    expect($ExtensionClass->child->name)->toBe('value');
+});


### PR DESCRIPTION
This commit introduces a new unit test to assert the functionality of model creation in the ServiceModel, alongside additional test classes for the purpose of testing. The test verifies that a model can be directly instantiated using the 'make' method for efficient extension.